### PR TITLE
Add support localized provider instance

### DIFF
--- a/fast_depends/__init__.py
+++ b/fast_depends/__init__.py
@@ -1,8 +1,9 @@
-from fast_depends.dependencies import dependency_provider
+from fast_depends.dependencies import dependency_provider, Provider
 from fast_depends.use import Depends, inject
 
 __all__ = (
     "Depends",
+    "Provider",
     "dependency_provider",
     "inject",
 )

--- a/fast_depends/dependencies/__init__.py
+++ b/fast_depends/dependencies/__init__.py
@@ -1,7 +1,8 @@
 from fast_depends.dependencies.model import Depends
-from fast_depends.dependencies.provider import dependency_provider
+from fast_depends.dependencies.provider import dependency_provider, Provider
 
 __all__ = (
     "Depends",
+    "Provider",
     "dependency_provider",
 )

--- a/fast_depends/dependencies/provider.py
+++ b/fast_depends/dependencies/provider.py
@@ -1,8 +1,4 @@
-from typing import Any, Callable, Dict, Protocol
-
-
-class HasDependencyOverrides(Protocol):
-    dependency_overrides: Dict[Callable[..., Any], Callable[..., Any]]
+from typing import Any, Callable, Dict
 
 
 class Provider:

--- a/fast_depends/dependencies/provider.py
+++ b/fast_depends/dependencies/provider.py
@@ -1,4 +1,8 @@
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Protocol
+
+
+class HasDependencyOverrides(Protocol):
+    dependency_overrides: Dict[Callable[..., Any], Callable[..., Any]]
 
 
 class Provider:

--- a/fast_depends/use.py
+++ b/fast_depends/use.py
@@ -6,7 +6,6 @@ from typing_extensions import ParamSpec, Protocol, TypeVar
 
 from fast_depends.core import CallModel, build_call_model
 from fast_depends.dependencies import dependency_provider, model
-from fast_depends.dependencies.provider import HasDependencyOverrides
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -41,9 +40,7 @@ class _InjectWrapper(Protocol[P, T]):
 def inject(  # pragma: no covers
     func: None,
     *,
-    dependency_overrides_provider: Optional[
-        HasDependencyOverrides
-    ] = dependency_provider,
+    dependency_overrides_provider: Optional[Any] = dependency_provider,
     extra_dependencies: Sequence[model.Depends] = (),
     wrap_model: Callable[[CallModel[P, T]], CallModel[P, T]] = lambda x: x,
 ) -> _InjectWrapper[P, T]:
@@ -54,9 +51,7 @@ def inject(  # pragma: no covers
 def inject(  # pragma: no covers
     func: Callable[P, T],
     *,
-    dependency_overrides_provider: Optional[
-        HasDependencyOverrides
-    ] = dependency_provider,
+    dependency_overrides_provider: Optional[Any] = dependency_provider,
     extra_dependencies: Sequence[model.Depends] = (),
     wrap_model: Callable[[CallModel[P, T]], CallModel[P, T]] = lambda x: x,
 ) -> Callable[P, T]:
@@ -66,9 +61,7 @@ def inject(  # pragma: no covers
 def inject(
     func: Optional[Union[Callable[P, T], Callable[P, Awaitable[T]]]] = None,
     *,
-    dependency_overrides_provider: Optional[
-        HasDependencyOverrides
-    ] = dependency_provider,
+    dependency_overrides_provider: Optional[Any] = dependency_provider,
     extra_dependencies: Sequence[model.Depends] = (),
     wrap_model: Callable[[CallModel[P, T]], CallModel[P, T]] = lambda x: x,
 ) -> Union[Union[Callable[P, T], Callable[P, Awaitable[T]]], _InjectWrapper[P, T],]:
@@ -86,7 +79,7 @@ def inject(
 
 
 def _resolve_overrides_provider(
-    dependency_overrides_provider: Optional[HasDependencyOverrides],
+    dependency_overrides_provider: Optional[Any],
 ) -> Optional[dict[Callable[..., Any], Callable[..., Any]]]:
     if not dependency_overrides_provider:
         return None
@@ -95,7 +88,7 @@ def _resolve_overrides_provider(
 
 
 def _wrap_inject(
-    dependency_overrides_provider: Optional[HasDependencyOverrides],
+    dependency_overrides_provider: Optional[Any],
     wrap_model: Callable[
         [CallModel[P, T]],
         CallModel[P, T],

--- a/fast_depends/use.py
+++ b/fast_depends/use.py
@@ -1,6 +1,6 @@
 from contextlib import AsyncExitStack, ExitStack
 from functools import wraps
-from typing import Any, Awaitable, Callable, Optional, Sequence, Union, overload
+from typing import Any, Dict, Awaitable, Callable, Optional, Sequence, Union, overload
 
 from typing_extensions import ParamSpec, Protocol, TypeVar
 
@@ -80,7 +80,7 @@ def inject(
 
 def _resolve_overrides_provider(
     dependency_overrides_provider: Optional[Any],
-) -> Optional[dict[Callable[..., Any], Callable[..., Any]]]:
+) -> Optional[Dict[Callable[..., Any], Callable[..., Any]]]:
     if not dependency_overrides_provider:
         return None
 

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from fast_depends import Depends, dependency_provider, inject
+from fast_depends import Depends, dependency_provider, inject, Provider
 
 
 @pytest.fixture
@@ -50,6 +50,48 @@ def test_sync_override(provider):
     assert not mock.original.called
 
 
+def test_sync_override_custom_provider(provider: Provider):
+    custom_provider = Provider()
+    mock = Mock()
+
+    def base_dep():  # pragma: no cover
+        mock.original()
+        return 1
+
+    def override_dep():
+        mock.override()
+        return 2
+
+    custom_provider.override(base_dep, override_dep)
+
+    def func(d=Depends(base_dep)):
+        assert d == 2
+
+    func = inject(func, dependency_overrides_provider=custom_provider)
+    func()
+
+    mock.override.assert_called_once()
+    assert not mock.original.called
+    assert not provider.dependency_overrides
+
+
+def test_sync_not_override_custom_provider(provider: Provider):
+    custom_provider = Provider()
+    mock = Mock()
+
+    def base_dep():  # pragma: no cover
+        mock.original()
+        return 1
+
+    def func(d=Depends(base_dep)):
+        assert d == 1
+
+    func = inject(func, dependency_overrides_provider=custom_provider)
+    func()
+
+    mock.original.assert_called_once()
+
+
 def test_sync_by_async_override(provider):
     def base_dep():  # pragma: no cover
         return 1
@@ -89,6 +131,50 @@ async def test_async_override(provider):
 
     mock.override.assert_called_once()
     assert not mock.original.called
+
+
+@pytest.mark.asyncio
+async def test_async_override_custom_provider(provider: Provider):
+    custom_provider = Provider()
+    mock = Mock()
+
+    async def base_dep():  # pragma: no cover
+        mock.original()
+        return 1
+
+    async def override_dep():
+        mock.override()
+        return 2
+
+    custom_provider.override(base_dep, override_dep)
+
+    async def func(d=Depends(base_dep)):
+        assert d == 2
+
+    func = inject(func, dependency_overrides_provider=custom_provider)
+    await func()
+
+    mock.override.assert_called_once()
+    assert not mock.original.called
+    assert not provider.dependency_overrides
+
+
+@pytest.mark.asyncio
+async def test_not_async_override_custom_provider(provider: Provider):
+    custom_provider = Provider()
+    mock = Mock()
+
+    async def base_dep():  # pragma: no cover
+        mock.original()
+        return 1
+
+    async def func(d=Depends(base_dep)):
+        assert d == 1
+
+    func = inject(func, dependency_overrides_provider=custom_provider)
+    await func()
+
+    mock.original.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR updates `_wrap_inject` to delay the evaluation of the `dependency_overrides` from the Provider to the function invocation so that one may use non-global dependency override providers.

Specifically, one can craft a Provider with a property that would only be evaluated at runtime so as to preserve the existing interface.