### PR TITLE
Use globals of original(wrapped) function

### DIFF
--- a/fast_depends/utils.py
+++ b/fast_depends/utils.py
@@ -81,8 +81,7 @@ def get_typed_signature(call: Callable[..., Any]) -> Tuple[inspect.Signature, An
     locals = collect_outer_stack_locals()
 
     # We unwrap call to get the original unwrapped function
-    while hasattr(call, "__wrapped__"):
-        call = call.__wrapped__
+    call = inspect.unwrap(call)
 
     globalns = getattr(call, "__globals__", {})
     typed_params = [
@@ -133,12 +132,11 @@ def get_typed_annotation(
     if isinstance(annotation, ForwardRef):
         annotation = evaluate_forwardref(annotation, globalns, locals)
 
-    if (
-        get_origin(annotation) is Annotated
-        and (args := get_args(annotation))
-    ):
+    if get_origin(annotation) is Annotated and (args := get_args(annotation)):
         solved_args = [get_typed_annotation(x, globalns, locals) for x in args]
-        annotation.__origin__, annotation.__metadata__ = solved_args[0], tuple(solved_args[1:])
+        annotation.__origin__, annotation.__metadata__ = solved_args[0], tuple(
+            solved_args[1:]
+        )
 
     return annotation
 

--- a/fast_depends/utils.py
+++ b/fast_depends/utils.py
@@ -133,11 +133,12 @@ def get_typed_annotation(
     if isinstance(annotation, ForwardRef):
         annotation = evaluate_forwardref(annotation, globalns, locals)
 
-    if get_origin(annotation) is Annotated and (args := get_args(annotation)):
+    if (
+        get_origin(annotation) is Annotated
+        and (args := get_args(annotation))
+    ):
         solved_args = [get_typed_annotation(x, globalns, locals) for x in args]
-        annotation.__origin__, annotation.__metadata__ = solved_args[0], tuple(
-            solved_args[1:]
-        )
+        annotation.__origin__, annotation.__metadata__ = solved_args[0], tuple(solved_args[1:])
 
     return annotation
 

--- a/fast_depends/utils.py
+++ b/fast_depends/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
 import inspect
+import sys
 from contextlib import AsyncExitStack, ExitStack, asynccontextmanager, contextmanager
 from typing import (
     TYPE_CHECKING,
@@ -80,7 +81,9 @@ def get_typed_signature(call: Callable[..., Any]) -> Tuple[inspect.Signature, An
 
     locals = collect_outer_stack_locals()
 
-    globalns = getattr(call, "__globals__", {})
+    # If call is wrapped, __globals__ point to the wrapper's globals
+    # We need to get the globals of the wrapped function
+    globalns = sys.modules.get(call.__module__).__dict__
     typed_params = [
         inspect.Parameter(
             name=param.name,

--- a/tests/test_prebuild.py
+++ b/tests/test_prebuild.py
@@ -26,9 +26,11 @@ def test_prebuild():
 
 
 def test_prebuild_with_wrapper():
+    func = noop_wrap(model_func)
+    assert func(Model(a="Hi!")) == "Hi!"
+
     # build_call_model should work even if function is wrapped with a
     # wrapper that is imported from different module
-    func = noop_wrap(model_func)
     call_model = build_call_model(func)
 
     assert call_model.model

--- a/tests/test_prebuild.py
+++ b/tests/test_prebuild.py
@@ -1,11 +1,36 @@
+from __future__ import annotations
+
 from fast_depends.core import build_call_model
 from fast_depends.use import inject
+
+from .wrapper import noop_wrap
+
+from pydantic import BaseModel
+
+
+class Model(BaseModel):
+    a: str
 
 
 def base_func(a: int) -> str:
     return "success"
 
 
+def model_func(m: Model) -> str:
+    return m.a
+
+
 def test_prebuild():
     model = build_call_model(base_func)
     inject()(None, model)(1)
+
+
+def test_prebuild_with_wrapper():
+    # build_call_model should work even if function is wrapped with a
+    # wrapper that is imported from different module
+    func = noop_wrap(model_func)
+    call_model = build_call_model(func)
+
+    assert call_model.model
+    # Fails if function unwrapping is not done at type introspection
+    call_model.model.model_rebuild()

--- a/tests/test_prebuild.py
+++ b/tests/test_prebuild.py
@@ -35,4 +35,9 @@ def test_prebuild_with_wrapper():
 
     assert call_model.model
     # Fails if function unwrapping is not done at type introspection
-    call_model.model.model_rebuild()
+
+    if hasattr(call_model.model, "model_rebuild"):
+        call_model.model.model_rebuild()
+    else:
+        # pydantic v1
+        call_model.model.update_forward_refs()

--- a/tests/wrapper.py
+++ b/tests/wrapper.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from functools import wraps
+
+
+def noop_wrap(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
Fixes: https://github.com/airtai/faststream/issues/1492

The original issue happens because the function is wrapped with a decorator, and type annotation resolution is done in the the decorator's globals. The fix uses `func.__module__` instead of `func.__globals__`

This is because `wraps` copies the `__module__` of the wrapped function, but not the `__globals__`