### PR TITLE
fix: Allow to inject async functions into async generators

### DIFF
--- a/fast_depends/core/build.py
+++ b/fast_depends/core/build.py
@@ -55,7 +55,7 @@ def build_call_model(
 
     is_call_async = is_coroutine_callable(call)
     if is_sync is None:
-        is_sync = not is_call_async
+        is_sync = not is_call_async and not inspect.isasyncgenfunction(call)
     else:
         assert not (
             is_sync and is_call_async

--- a/fast_depends/core/build.py
+++ b/fast_depends/core/build.py
@@ -53,9 +53,9 @@ def build_call_model(
 ) -> CallModel[P, T]:
     name = getattr(call, "__name__", type(call).__name__)
 
-    is_call_async = is_coroutine_callable(call)
+    is_call_async = is_coroutine_callable(call) or is_async_gen_callable(call)
     if is_sync is None:
-        is_sync = not is_call_async and not is_async_gen_callable(call)
+        is_sync = not is_call_async
     else:
         assert not (
             is_sync and is_call_async

--- a/fast_depends/core/build.py
+++ b/fast_depends/core/build.py
@@ -55,7 +55,7 @@ def build_call_model(
 
     is_call_async = is_coroutine_callable(call)
     if is_sync is None:
-        is_sync = not is_call_async and not inspect.isasyncgenfunction(call)
+        is_sync = not is_call_async and not is_async_gen_callable(call)
     else:
         assert not (
             is_sync and is_call_async

--- a/tests/async/test_depends.py
+++ b/tests/async/test_depends.py
@@ -422,12 +422,19 @@ async def test_generator():
     mock = Mock()
 
     async def func():
+        mock.async_call()
+
+    async def gen_func():
         mock.start()
         yield
         mock.end()
 
     @inject
-    async def simple_func(a: str, d=Depends(func)) -> int:
+    async def simple_func(
+        a: str,
+        d=Depends(gen_func),
+        d2=Depends(func),
+    ) -> int:
         for _ in range(2):
             yield a
 
@@ -436,6 +443,7 @@ async def test_generator():
         assert not mock.end.called
         assert i == 1
 
+    mock.async_call.assert_called_once()
     mock.end.assert_called_once()
 
 


### PR DESCRIPTION
When you try to inject asynchronous dependencies into an asynchronous generator like this:
```python
async def some_dep() -> int:
    return 5

@inject
async def some_async_gen(value: Annotated[int, Depends(some_dep)]):
    yield value
```
you see the error ``You cannot use async dependency `some_dep` at sync main``.

This pull request allows the `inject` function be used in such context. Still do not work with `asynccontextmanager` decorator though.