### PR TITLE
fix: Allow to inject async functions into functions wrapped with asynccontextmanager

### DIFF
--- a/fast_depends/use.py
+++ b/fast_depends/use.py
@@ -184,7 +184,7 @@ def _wrap_inject(
 
 
 class solve_async_gen:
-    _iter: Optional[AsyncIterator[Any]]
+    _iter: Optional[AsyncIterator[Any]] = None
 
     def __init__(
         self,
@@ -231,7 +231,7 @@ class solve_async_gen:
 
 
 class solve_gen:
-    _iter: Optional[Iterator[Any]]
+    _iter: Optional[Iterator[Any]] = None
 
     def __init__(
         self,

--- a/tests/async/test_depends.py
+++ b/tests/async/test_depends.py
@@ -474,7 +474,7 @@ async def test_default_key_value():
 
 @pytest.mark.anyio
 async def test_asynccontextmanager():
-    async def dep(a: str = "a"):
+    async def dep(a: str):
         return a
 
     @asynccontextmanager

--- a/tests/async/test_depends.py
+++ b/tests/async/test_depends.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from functools import partial
 from unittest.mock import Mock
@@ -469,3 +470,17 @@ async def test_default_key_value():
         return a
 
     assert await func() == "a"
+
+
+@pytest.mark.anyio
+async def test_asynccontextmanager():
+    async def dep(a: str = "a"):
+        return a
+
+    @asynccontextmanager
+    @inject
+    async def func(a: str, b: str = Depends(dep)):
+        yield a == b
+
+    async with func("a") as is_equal:
+        assert is_equal

--- a/tests/sync/test_depends.py
+++ b/tests/sync/test_depends.py
@@ -356,7 +356,7 @@ def test_default_key_value():
 
 
 def test_contextmanager():
-    def dep(a: str = "a"):
+    def dep(a: str):
         return a
 
     @contextmanager

--- a/tests/sync/test_depends.py
+++ b/tests/sync/test_depends.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial
 from unittest.mock import Mock
@@ -352,3 +353,16 @@ def test_default_key_value():
         return a
 
     assert func() == "a"
+
+
+def test_contextmanager():
+    def dep(a: str = "a"):
+        return a
+
+    @contextmanager
+    @inject
+    def func(a: str, b: str = Depends(dep)):
+        yield a == b
+
+    with func("a") as is_equal:
+        assert is_equal


### PR DESCRIPTION
When you try to inject synchronous or asynchronous dependencies into an asynchronous generator wrapped with `contextlib.asynccontextmanager` like this:

```python3
async def some_dep() -> int:
    return 5

@asynccontextmanager
@inject
async def some_async_gen(value: Annotated[int, Depends(some_dep)]):
    yield value
```
you see the error `AttributeError: 'solve_async_gen' object has no attribute '_iter'`.

The reverse order of the decorators works for sync dependincies only and raises the error ``AssertionError: You cannot use async dependency `some_dep` at sync main`` for async ones.

This pull request allows the inject function be used in such context with the direct order of the decorators. I don't see any possibility to provide the ability to use the reverse order because of the way `asynccontextmanager` is implemented in the standard library:
```python3
# contextlib.py - python 3.12
def asynccontextmanager(func):
    @wraps(func)
    def helper(*args, **kwds):
        return _AsyncGeneratorContextManager(func, args, kwds)
    return helper
```
As you can see, the decorator returns the synchronous wrapper, so when fast_depends execute `build_call_model` it determines the function as synchronous.