### PR TITLE
fix: Allow to use */** arguments with non-standard names

### DIFF
--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -19,3 +19,33 @@ def test_params():
 
     assert set(model.params.keys()) == {"a", "b"}
     assert set(model.flat_params.keys()) == {"a", "b", "c", "m", "n"}
+
+
+def test_args_kwargs_params():
+    def func1(m): ...
+
+    def func2(c, b=Depends(func1), d=CustomField()):  # noqa: B008
+        ...
+
+    def func3(b): ...
+
+    def default_var_names(a, *args, b, m=Depends(func2), k=Depends(func3), **kwargs):
+        return a, args, b, kwargs
+
+    def custom_var_names(a, *args_, b, m=Depends(func2), k=Depends(func3), **kwargs_):
+        return a, args_, b, kwargs_
+
+    def extra_func(n): ...
+
+    model1 = build_call_model(default_var_names, extra_dependencies=(Depends(extra_func),))
+
+    assert set(model1.params.keys()) == {"a", "args", "b", "kwargs"}
+    assert set(model1.flat_params.keys()) == {"a", "args", "b", "kwargs", "c", "m", "n"}
+
+    model2 = build_call_model(custom_var_names, extra_dependencies=(Depends(extra_func),))
+
+    assert set(model2.params.keys()) == {"a", "args_", "b", "kwargs_"}
+    assert set(model2.flat_params.keys()) == {"a", "args_", "b", "kwargs_", "c", "m", "n"}
+
+    assert default_var_names(1, *('a'), b=2, **{'kw': 'kw'}) == (1, ('a',), 2, {'kw': 'kw'})
+    assert custom_var_names(1, *('a'), b=2, **{'kw': 'kw'}) == (1, ('a',), 2, {'kw': 'kw'})


### PR DESCRIPTION
Right now it is only allowed to use astersisk arguments only if they are named as args and kwargs:
```python3
@inject
def some_func(**kwargs):  # works
    ...

@inject
def another_func(**context):  # fails
    ...
```
If you try to use another name in such a context, you will get the ValidationError like this:
```
ValidationError: 1 validation error for some_func
context
  Field required [type=missing]
    For further information visit https://errors.pydantic.dev/2.8/v/missing
```
This applies to both `*args` and `**kwargs` arguments with custom names. This pull request is to fix this behaviour