### PR TITLE
Fix type hint for func argument to inject

### DIFF
--- a/fast_depends/use.py
+++ b/fast_depends/use.py
@@ -48,7 +48,7 @@ class _InjectWrapper(Protocol[P, T]):
 
 @overload
 def inject(  # pragma: no cover
-    func: None,
+    func: None = None,
     *,
     cast: bool = True,
     extra_dependencies: Sequence[model.Depends] = (),


### PR DESCRIPTION
As far as I can tell, making this change has no impact on the runtime behavior, and doesn't cause any code that currently passes type-checking to fail. However, it makes it so that doing, e.g.:
```python
@inject(cast=False)
def my_func(my_dep: Any = Depends(my_dep_function)):
    ...
```
doesn't produce a type error.