### PR TITLE
fix: Don't reset state of generator on each invocation

### DIFF
--- a/fast_depends/use.py
+++ b/fast_depends/use.py
@@ -199,7 +199,6 @@ class solve_async_gen:
         self.overrides = overrides
 
     def __aiter__(self) -> "solve_async_gen":
-        self._iter = None
         self.stack = AsyncExitStack()
         return self
 
@@ -246,7 +245,6 @@ class solve_gen:
         self.overrides = overrides
 
     def __iter__(self) -> "solve_gen":
-        self._iter = None
         self.stack = ExitStack()
         return self
 

--- a/tests/sync/test_depends.py
+++ b/tests/sync/test_depends.py
@@ -2,6 +2,7 @@ import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial
+from typing import Generator
 from unittest.mock import Mock
 
 import pytest
@@ -366,3 +367,19 @@ def test_contextmanager():
 
     with func("a") as is_equal:
         assert is_equal
+
+
+def test_generator_iter():
+    # ref: https://github.com/Lancetnik/FastDepends/issues/165
+
+    def simple_dependency(a: int, b: int = 3):
+        return a + b
+
+    @inject
+    def method(a: int, d: int = Depends(simple_dependency)) -> Generator[int, None, None]:
+        yield from range(a + d)
+
+    iterator = method(5)
+
+    assert len(list(iterator)) == 13
+    assert len(list(iterator)) == 0


### PR DESCRIPTION
See #165 

I didn't remove that in #125 because I thought there are no cases where it would break something. Now we have at least one case, so let's do that