### PR TITLE
fix: Allow depends on injected generators

### DIFF
--- a/fast_depends/_compat.py
+++ b/fast_depends/_compat.py
@@ -1,6 +1,6 @@
 import sys
 from importlib.metadata import version as get_version
-from typing import Any, Dict, Optional, Tuple, Type
+from typing import Any, Dict, Generic, Optional, Tuple, Type, TypeVar
 
 from pydantic import BaseModel, create_model
 from pydantic.version import VERSION as PYDANTIC_VERSION
@@ -71,3 +71,14 @@ else:
         from exceptiongroup import ExceptionGroup as ExceptionGroup
     else:
         ExceptionGroup = ExceptionGroup
+
+
+if sys.version_info >= (3, 9):
+    from functools import partial
+else:
+    from functools import partial as _partial_base
+
+    T = TypeVar("T")
+
+    class partial(_partial_base, Generic[T]):
+        pass

--- a/fast_depends/core/build.py
+++ b/fast_depends/core/build.py
@@ -30,6 +30,7 @@ from fast_depends.utils import (
     is_async_gen_callable,
     is_coroutine_callable,
     is_gen_callable,
+    solve_wrapper,
 )
 
 CUSTOM_ANNOTATIONS = (Depends, CustomField)
@@ -148,6 +149,9 @@ def build_call_model(
         if dep:
             if not cast:
                 dep.cast = False
+
+            if isinstance(dep.dependency, solve_wrapper):
+                dep.dependency = dep.dependency.call
 
             dependencies[param_name] = build_call_model(
                 dep.dependency,

--- a/fast_depends/use.py
+++ b/fast_depends/use.py
@@ -1,5 +1,5 @@
 from contextlib import AsyncExitStack, ExitStack
-from functools import partial, wraps
+from functools import wraps
 from typing import (
     Any,
     AsyncIterator,
@@ -19,6 +19,7 @@ from typing_extensions import ParamSpec
 from fast_depends._compat import ConfigDict
 from fast_depends.core import CallModel, build_call_model
 from fast_depends.dependencies import dependency_provider, model
+from fast_depends.utils import solve_wrapper
 
 P = ParamSpec("P")
 T = TypeVar("T")
@@ -138,7 +139,7 @@ def _wrap_inject(
             injected_wrapper: Callable[P, T]
 
             if real_model.is_generator:
-                injected_wrapper = partial(solve_async_gen, real_model, overrides)  # type: ignore[assignment]
+                injected_wrapper = solve_wrapper(solve_async_gen, real_model, overrides)  # type: ignore[assignment]
 
             else:
 
@@ -159,7 +160,7 @@ def _wrap_inject(
 
         else:
             if real_model.is_generator:
-                injected_wrapper = partial(solve_gen, real_model, overrides)  # type: ignore[assignment]
+                injected_wrapper = solve_wrapper(solve_gen, real_model, overrides)  # type: ignore[assignment]
 
             else:
 

--- a/fast_depends/utils.py
+++ b/fast_depends/utils.py
@@ -27,7 +27,7 @@ from typing_extensions import (
     get_origin,
 )
 
-from fast_depends._compat import evaluate_forwardref
+from fast_depends._compat import evaluate_forwardref, partial
 
 if TYPE_CHECKING:
     from types import FrameType
@@ -192,3 +192,16 @@ async def async_map(
 ) -> AsyncIterable[T]:
     async for i in async_iterable:
         yield func(i)
+
+
+class solve_wrapper(partial[T]):
+    call: Callable[..., T]
+
+    def __new__(
+        cls, func: Callable[..., T], *args: Any, **kwargs: Any,
+    ) -> "solve_wrapper[T]":
+        assert len(args) > 0, "Model should be passed as first argument"
+        model = args[0]
+        self = super().__new__(cls, func, *args, **kwargs)
+        self.call = model.call
+        return self

--- a/tests/async/test_depends.py
+++ b/tests/async/test_depends.py
@@ -503,3 +503,19 @@ async def test_asyncgenerator_iter():
 
     assert len([v async for v in iterator]) == 13
     assert len([v async for v in iterator]) == 0
+
+
+@pytest.mark.anyio
+async def test_solve_wrapper():
+    @inject
+    async def dep1(a: int):
+        yield a + 1
+
+    async def dep2(a: int):
+        yield a + 2
+
+    @inject
+    async def func(a: int, b: int = Depends(dep1), c: int = Depends(dep2)):
+        return a, b, c
+
+    assert await func(1) == (1, 2, 3)

--- a/tests/sync/test_depends.py
+++ b/tests/sync/test_depends.py
@@ -383,3 +383,18 @@ def test_generator_iter():
 
     assert len(list(iterator)) == 13
     assert len(list(iterator)) == 0
+
+
+def test_solve_wrapper():
+    @inject
+    def dep1(a: int):
+        yield a + 1
+
+    def dep2(a: int):
+        yield a + 2
+
+    @inject
+    def func(a: int, b: int = Depends(dep1), c: int = Depends(dep2)):
+        return a, b, c
+
+    assert func(1) == (1, 2, 3)


### PR DESCRIPTION
Inject did not work properly when you made a dependency on already injected generator function (both sync and async)

```python
from fast_depends import Depends, inject

@inject
def dep():
    yield 5

@inject
def func1(a = Depends(dep)):
    print(a)

# print "<fast_depends.use.solve_gen object at 0x...>"

@inject
def func2(a: int = Depends(dep)):
    print(a)

# raise ValidationError:
# ...
# ValidationError: 1 validation error for func2
# a
#   Input should be a valid integer [type=int_type, input_value=<fast_depends.use.solve_g...bject at 0x...>, input_type=solve_gen]
# ...
```

