### PR TITLE
feat: allow overriding CustomField dependencies via dependency_provider

### DIFF
--- a/fast_depends/core/model.py
+++ b/fast_depends/core/model.py
@@ -241,10 +241,22 @@ class CallModel:
 
         if self.custom_fields:
             for custom in self.custom_fields.values():
-                if custom.field:
-                    custom.use_field(kwargs)
+                custom_override = provider.overrides.get(
+                    custom
+                ) or provider.overrides.get(type(custom))
+                if custom_override:
+                    kwargs[custom.param_name] = custom_override.solve(
+                        *args,
+                        stack=stack,
+                        cache_dependencies=cache_dependencies,
+                        nested=True,
+                        **kwargs,
+                    )
                 else:
-                    kwargs = custom.use(**kwargs)
+                    if custom.field:
+                        custom.use_field(kwargs)
+                    else:
+                        kwargs = custom.use(**kwargs)
 
         final_args, final_kwargs = cast_gen.send(kwargs)
 
@@ -310,9 +322,7 @@ class CallModel:
 
         for dep_arg, dep_key in self.dependencies.items():
             if dep_arg not in kwargs:
-                kwargs[dep_arg] = await provider.get_dependant(
-                    dep_key
-                ).asolve(
+                kwargs[dep_arg] = await provider.get_dependant(dep_key).asolve(
                     *args,
                     stack=stack,
                     cache_dependencies=cache_dependencies,
@@ -326,10 +336,22 @@ class CallModel:
             try:
                 async with anyio.create_task_group() as tg:
                     for custom in self.custom_fields.values():
-                        if custom.field:
-                            tg.start_soon(run_async, custom.use_field, kwargs)
+                        custom_override = provider.overrides.get(
+                            custom
+                        ) or provider.overrides.get(type(custom))
+                        if custom_override:
+                            kwargs[custom.param_name] = await custom_override.asolve(
+                                *args,
+                                stack=stack,
+                                cache_dependencies=cache_dependencies,
+                                nested=True,
+                                **kwargs,
+                            )
                         else:
-                            custom_to_solve.append(custom)
+                            if custom.field:
+                                tg.start_soon(run_async, custom.use_field, kwargs)
+                            else:
+                                custom_to_solve.append(custom)
 
             except ExceptionGroup as exgr:
                 for ex in exgr.exceptions:

--- a/fast_depends/dependencies/provider.py
+++ b/fast_depends/dependencies/provider.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 from fast_depends.core import build_call_model
+from fast_depends.library import CustomField
 
 if TYPE_CHECKING:
     from fast_depends.core import CallModel
@@ -41,7 +42,7 @@ class Provider:
 
     def override(
         self,
-        original: Callable[..., Any],
+        original: "Callable[..., Any] | CustomField",
         override: Callable[..., Any],
     ) -> None:
         key = self.__get_original_key(original)
@@ -51,7 +52,7 @@ class Provider:
         if original_dependant := self.dependencies.get(key):
             serializer_cls = original_dependant.serializer_cls
 
-        else:
+        elif not isinstance(original, CustomField):
             self.dependencies[key] = build_call_model(
                 original,
                 dependency_provider=self,
@@ -67,7 +68,7 @@ class Provider:
 
     def __setitem__(
         self,
-        key: Callable[..., Any],
+        key: "Callable[..., Any] | CustomField",
         value: Callable[..., Any],
     ) -> None:
         """Alias for `provider[key] = value` syntax"""
@@ -76,12 +77,12 @@ class Provider:
     @contextmanager
     def scope(
         self,
-        original: Callable[..., Any],
+        original: "Callable[..., Any] | CustomField",
         override: Callable[..., Any],
     ) -> Iterator[None]:
         self.override(original, override)
         yield
         self.overrides.pop(self.__get_original_key(original), None)
 
-    def __get_original_key(self, original: Callable[..., Any]) -> Key:
+    def __get_original_key(self, original: "Callable[..., Any] | CustomField") -> Key:
         return original

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -1,10 +1,11 @@
 from collections.abc import AsyncGenerator, Generator
-from typing import Annotated
+from typing import Annotated, Any
 from unittest.mock import Mock
 
 import pytest
 
 from fast_depends import Depends, Provider, inject
+from fast_depends.library import CustomField
 
 
 def test_not_override(provider: Provider) -> None:
@@ -305,3 +306,69 @@ def test_clear_overrides(provider: Provider) -> None:
     assert len(provider.overrides) == 0
     assert len(provider.dependencies) == 1
     assert func() == 1  # original dep called
+
+
+class Header(CustomField):
+    def use(self, /, **kwargs: dict[str, Any]) -> dict[str, Any]:
+        kwargs = super().use(**kwargs)
+        kwargs[self.param_name] = kwargs.get("headers", {}).get(self.param_name)
+        return kwargs
+
+
+def test_override_custom_field_class(provider: Provider) -> None:
+    @inject(dependency_provider=provider)
+    def func(h: int = Header()) -> int:
+        return h
+
+    provider.override(Header, lambda: 1)
+
+    assert func() == 1
+
+
+def test_override_custom_field_instance(provider: Provider) -> None:
+    h = Header()
+
+    @inject(dependency_provider=provider)
+    def func(header_field: int = h) -> int:
+        return header_field
+
+    provider.override(h, lambda: 2)
+
+    assert func() == 2
+
+
+@pytest.mark.anyio
+async def test_async_override_custom_field(provider: Provider) -> None:
+    h = Header()
+
+    @inject(dependency_provider=provider)
+    async def func(header_field: int = h) -> int:
+        return header_field
+
+    async def override_dep() -> int:
+        return 3
+
+    provider.override(h, override_dep)
+
+    assert await func() == 3
+
+
+class HeaderField(CustomField):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.field = True
+
+    def use_field(self, kwargs: dict[str, Any]) -> None:
+        kwargs[self.param_name] = kwargs.get("headers", {}).get(self.param_name)
+
+
+def test_override_custom_field_field(provider: Provider) -> None:
+    h = HeaderField()
+
+    @inject(dependency_provider=provider)
+    def func(header_field: int = h) -> int:
+        return header_field
+
+    provider.override(h, lambda: 2)
+
+    assert func() == 2


### PR DESCRIPTION
## Summary
This PR adds support for overriding `CustomField` classes and instances using `dependency_provider.override()`, addressing #176.

## Problem
Closes #176 
Currently, users are unable to override `CustomField`s at runtime using `dependency_provider` for testing purposes. `dependency_provider.override()` crashes or has no effect when provided with a `CustomField` class or instance.

## Solution
Modified `CallModel._solve` and `_asolve` to intercept evaluations of `CustomField` and apply mocked overrides from `provider.overrides` (checked by instance or type).
Updated `Provider.override` to skip calling `build_call_model` on `CustomField` objects to prevent instantiation/signature errors. Type annotations updated to accept `CustomField`.
Added tests in `test_overrides.py` to ensure both `CustomField` classes and specific instances can be safely overridden.

## Testing
- Tests pass locally.
- Verified both sync/async paths and `field=True/False` variants.

---
*This PR was created with AI assistance.*